### PR TITLE
Add lxml demo

### DIFF
--- a/lxmldemo.py
+++ b/lxmldemo.py
@@ -1,2 +1,38 @@
-import lxml
+import urllib
+import lxml.html
+import lxml.html.soupparser
 
+
+def print_speakers(root):
+    print 'Root:', root
+
+    e = root.xpath('//h3[contains(.,"E")]')
+    if e:
+        e0 = e[0]
+        print 'Heading:', e0
+
+        speakers = e0.xpath('following-sibling::ul[1]/li')
+        print 'Speakers:', speakers
+
+        for speaker in speakers:
+            print speaker.xpath('.//text()')
+
+url = 'https://ep2015.europython.eu/en/speakers/'
+
+print
+print 'Use fast lxml.html library'
+
+reader = urllib.urlopen(url)
+tree = lxml.html.parse(reader)
+print 'Tree:', tree
+root = tree.getroot()
+print_speakers(root)
+
+
+print
+print 'soupparser module was added in lxml 2.0.3'
+
+reader = urllib.urlopen(url)
+content = reader.read()
+root = lxml.html.soupparser.fromstring(content)
+print_speakers(root)


### PR DESCRIPTION
Output looks something like:

```
$ python lxmldemo.py

Use fast lxml.html library
Tree: <lxml.etree._ElementTree object at 0x7fe2dcede758>
Root: <Element html at 0x7fe2dce50208>
Heading: <Element h3 at 0x7fe2dce50260>
Speakers: [<Element li at 0x7fe2dce502b8>, <Element li at 0x7fe2dce50310>, <Element li at 0x7fe2dce50368>, <Element li at 0x7fe2dce503c0>, <Element li at 0x7fe2dce50418>, <Element li at 0x7fe2dce50470>, <Element li at 0x7fe2dce504c8>]
['Ignacio Elola']
['Pablo Enfedaque']
['Stephan Erb']
[u'Jes\xfas Espino']
[u'Llu\xeds Esquerda']
['oier etxaniz']
['Shane Evans']

soupparser module was added in lxml 2.0.3
Root: <Element html at 0x7fe2dce72730>
Heading: <Element h3 at 0x7fe2dce72838>
Speakers: [<Element li at 0x7fe2dce72940>, <Element li at 0x7fe2dce728e8>, <Element li at 0x7fe2dce72890>, <Element li at 0x7fe2dce72998>, <Element li at 0x7fe2dce72aa0>, <Element li at 0x7fe2dce729f0>, <Element li at 0x7fe2dce72af8>]
['Ignacio Elola']
['Pablo Enfedaque']
['Stephan Erb']
[u'Jes\xfas Espino']
[u'Llu\xeds Esquerda']
['oier etxaniz']
['Shane Evans']
```
